### PR TITLE
fix: Consistent file path references for features/active.json

### DIFF
--- a/.claude-harness/init.sh
+++ b/.claude-harness/init.sh
@@ -13,8 +13,10 @@ else
 fi
 echo ""
 echo "=== Pending Features ==="
-if [ -f .claude-harness/feature-list.json ]; then
+if [ -f .claude-harness/features/active.json ]; then
+  cat .claude-harness/features/active.json
+elif [ -f .claude-harness/feature-list.json ]; then
   cat .claude-harness/feature-list.json
 else
-  echo "No .claude-harness/feature-list.json found"
+  echo "No .claude-harness/features/active.json found"
 fi

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-harness",
   "description": "Long-running agent harness with 4-layer memory architecture, failure prevention, test-driven features, bug fix tracking, GitHub integration, and multi-agent orchestration",
-  "version": "3.1.0",
+  "version": "3.3.1",
   "author": {
     "name": "panayiotis"
   },

--- a/README.md
+++ b/README.md
@@ -584,6 +584,8 @@ claude mcp add github -s user
 
 | Version | Changes |
 |---------|---------|
+| **3.3.1** | **Bug Fix**: Fixed inconsistent file path references - all commands now consistently use `features/active.json` instead of legacy `feature-list.json` |
+| **3.3.0** | **Self-Improving Skills**: `/reflect` command - Extract rules from user corrections, auto-reflect at checkpoint, display learned rules at session start |
 | **3.2.0** | **Memory System Utilization**: Commands now actually use the 4-layer memory system - `/start` compiles context, `/implement` queries failures before attempting, `/checkpoint` persists to memory |
 | **3.1.0** | **Bug Fix Command**: `/fix` - Create bug fixes linked to original features with shared memory context, GitHub issue linkage, and PATCH versioning |
 | **3.0.0** | **Memory Architecture Release** - See release notes above |

--- a/commands/checkpoint.md
+++ b/commands/checkpoint.md
@@ -15,7 +15,7 @@ Create a checkpoint of the current session:
 ## Phase 1.5: Capture Working Context
 
 1.5. Update `.claude-harness/working-context.json` with current working state:
-   - Read `.claude-harness/feature-list.json` to identify active feature (first with passes=false)
+   - Read `.claude-harness/features/active.json` (or legacy `feature-list.json`) to identify active feature (first with passes=false)
    - Set `activeFeature` to the feature ID and `summary` to feature name
    - Populate `workingFiles` from:
      - Feature's `relatedFiles` array

--- a/commands/feature.md
+++ b/commands/feature.md
@@ -3,7 +3,7 @@ description: Add a new feature - creates GitHub issue + branch (if MCP configure
 argumentsPrompt: Feature description
 ---
 
-Add a new feature to .claude-harness/feature-list.json and create GitHub Issue:
+Add a new feature to .claude-harness/features/active.json and create GitHub Issue:
 
 Arguments: $ARGUMENTS
 
@@ -22,7 +22,7 @@ Arguments: $ARGUMENTS
    - Priority: `priority:high`, `priority:medium`, `priority:low`
    - Type: `feature`, `enhancement`, `bugfix`, `refactor`, `docs`
    - Status: `status:in-progress`, `status:blocked`, `status:ready-for-review`
-4. Add to .claude-harness/feature-list.json with:
+4. Add to .claude-harness/features/active.json with:
    - id, name, description, priority (default 1)
    - passes: false
    - verification: Generate reasonable verification steps (human-readable)

--- a/commands/orchestrate.md
+++ b/commands/orchestrate.md
@@ -10,13 +10,13 @@ Arguments: $ARGUMENTS
 ## Phase 1: Task Analysis
 
 1. Identify the target:
-   - If $ARGUMENTS matches a feature ID (e.g., "feature-001"), read from .claude-harness/feature-list.json
+   - If $ARGUMENTS matches a feature ID (e.g., "feature-001"), read from .claude-harness/features/active.json
    - Otherwise, treat $ARGUMENTS as a task description
 
 2. Read orchestration context:
    - Read `.claude-harness/agent-context.json` for current state (create if missing with initial structure)
    - Read `.claude-harness/agent-memory.json` for learned patterns (create if missing)
-   - Read `.claude-harness/feature-list.json` if working on a tracked feature
+   - Read `.claude-harness/features/active.json` if working on a tracked feature
 
 3. Analyze the task:
    - Identify file types that will be modified (.tsx, .ts, .py, etc.)
@@ -185,7 +185,7 @@ Arguments: $ARGUMENTS
       - Add discovered patterns to learnedPatterns
 
 14. Update feature tracking:
-    - If working on a tracked feature, update .claude-harness/feature-list.json:
+    - If working on a tracked feature, update .claude-harness/features/active.json:
       - Add new files to relatedFiles
       - Update verification status if applicable
 
@@ -263,7 +263,7 @@ Arguments: $ARGUMENTS
     ```
 
 19. Update feature status if verification passed:
-    - Set `passes: true` in `.claude-harness/feature-list.json`
+    - Set `passes: true` in `.claude-harness/features/active.json`
     - Create git checkpoint with verification results
 
 ## Error Recovery

--- a/commands/start.md
+++ b/commands/start.md
@@ -143,7 +143,7 @@ Before anything else, check if legacy root-level harness files need migration:
 9. Read `.claude-harness/claude-progress.json` for session context
 
 10. Read `.claude-harness/features/active.json` (or legacy `feature-list.json`) to identify next priority
-   - If the file is too large to read (>25000 tokens), use: `grep -A 5 "passes.*false" .claude-harness/feature-list.json` to see pending features
+   - If the file is too large to read (>25000 tokens), use: `grep -A 5 "passes.*false" .claude-harness/features/active.json` to see pending features
    - Run `/claude-harness:checkpoint` to auto-archive completed features and reduce file size
 
 11. Optionally check `.claude-harness/features/archive.json` (or legacy `feature-archive.json`) to see completed feature count/history
@@ -219,7 +219,7 @@ Before anything else, check if legacy root-level harness files need migration:
    - Open issues with "feature" label
    - Open PRs from feature branches
    - CI/CD status for open PRs
-   - Cross-reference with .claude-harness/feature-list.json
+   - Cross-reference with .claude-harness/features/active.json
 
 17. Sync GitHub Issues with .claude-harness/features/active.json:
    - For each GitHub issue with "feature" label NOT in active.json:


### PR DESCRIPTION
## Summary
- Fixed inconsistent file path references where some commands used `feature-list.json` instead of the v3.0 path `features/active.json`
- All commands now consistently use `features/active.json` with legacy fallback where appropriate

## Files Changed
- `commands/feature.md` - Updated to use `features/active.json`
- `commands/orchestrate.md` - Updated 4 references to use `features/active.json`
- `commands/checkpoint.md` - Updated to use `features/active.json`
- `commands/start.md` - Updated grep example
- `.claude-harness/init.sh` - Check `features/active.json` first with fallback to legacy
- `.claude-plugin/plugin.json` - Version bump to 3.3.1
- `README.md` - Added changelog entry

## Related
Fixes #16
Related to #7 (feature-004: Move harness files to dedicated .claude-harness/ directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)