### PR TITLE
feat: v7.0.0 metadata + changelog

### DIFF
--- a/hooks/permission-request.sh
+++ b/hooks/permission-request.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Harness PermissionRequest Hook v6.4.0
+# Claude Harness PermissionRequest Hook v7.0.0
 # Autonomous mode acceleration — auto-approve safe ops, auto-deny destructive
 # No matcher — fires for all permission requests
 # No-op when not in autonomous mode

--- a/hooks/post-tool-use-failure.sh
+++ b/hooks/post-tool-use-failure.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Harness PostToolUseFailure Hook v6.4.0
+# Claude Harness PostToolUseFailure Hook v7.0.0
 # Real-time failure learning — records test/build/lint failures
 # Matcher: "Bash"
 # Appends to memory/episodic/failures.json for future reference

--- a/hooks/post-tool-use.sh
+++ b/hooks/post-tool-use.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Harness PostToolUse Hook v6.4.0
+# Claude Harness PostToolUse Hook v7.0.0
 # Async streaming verification — runs tests in background after code edits
 # Matcher: "Edit|Write", async: true
 # Results delivered next turn as additionalContext

--- a/hooks/pre-tool-use.sh
+++ b/hooks/pre-tool-use.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Harness PreToolUse Hook v6.4.0
+# Claude Harness PreToolUse Hook v7.0.0
 # Branch safety + state protection
 # Matchers: "Bash" and "Edit|Write" (registered separately in hooks.json)
 # Exit 0 with permissionDecision: "deny" = block the tool call

--- a/hooks/session-start-compact.sh
+++ b/hooks/session-start-compact.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Harness SessionStart (compact) Hook v6.4.0
+# Claude Harness SessionStart (compact) Hook v7.0.0
 # Post-compaction context recovery — re-injects critical state after compaction
 # Matcher: "compact" — only fires when source is context compaction
 # Complements pre-compact.sh backup with active context restoration

--- a/hooks/subagent-start.sh
+++ b/hooks/subagent-start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Harness SubagentStart Hook v6.4.0
+# Claude Harness SubagentStart Hook v7.0.0
 # Teammate context injection — injects harness state into spawned teammates
 # No matcher — fires for all subagent/teammate starts
 # Injects: active feature, TDD phase, recent failures, verification cmds

--- a/tests/test-v7-metadata.sh
+++ b/tests/test-v7-metadata.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# v7.0.0 Metadata & Changelog Tests for feature-023
+
+HOOKS_DIR="$(cd "$(dirname "$0")/../hooks" && pwd)"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+test_it() {
+  local desc="$1"; shift
+  if eval "$@" 2>/dev/null; then ((PASS++)); echo "  PASS: $desc"
+  else ((FAIL++)); echo "  FAIL: $desc"; fi
+}
+
+echo "=== v7.0.0 Metadata & Changelog Tests ==="
+echo ""
+
+# Test 1: plugin.json version is 7.0.0
+test_it "plugin.json version is 7.0.0" \
+  'grep -q "\"version\": \"7.0.0\"" "$ROOT_DIR/.claude-plugin/plugin.json"'
+
+# Test 2: All hook files have v7.0.0 in header (line 2)
+OLD_HOOKS=0
+for f in "$HOOKS_DIR"/*.sh; do
+  header=$(sed -n '2p' "$f")
+  if echo "$header" | grep -q 'v[0-9]' && ! echo "$header" | grep -q 'v7.0.0'; then
+    OLD_HOOKS=$((OLD_HOOKS + 1))
+  fi
+done
+test_it "All hook version headers are v7.0.0 (${OLD_HOOKS} outdated)" \
+  '[ "$OLD_HOOKS" -eq 0 ]'
+
+# Test 3: README.md has v7.0.0 changelog entry
+test_it "README.md has v7.0.0 changelog entry" \
+  'grep -q "7\.0\.0" "$ROOT_DIR/README.md" | head -1 && grep -q "7\.0\.0" "$ROOT_DIR/README.md"'
+
+# Test 4: README.md v7.0.0 entry mentions key features
+test_it "README.md v7.0.0 entry mentions hook compliance and performance" \
+  'grep -A5 "7\.0\.0" "$ROOT_DIR/README.md" | grep -qi "hook\|performance\|compliance\|optimization"'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ $FAIL -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
Closes #38

- Updated all 6 remaining hook version headers from v6.4.0 to v7.0.0
- Added comprehensive v7.0.0 changelog entry to README.md covering all 4 sub-features:
  - Hook compliance fixes (feature-019)
  - Flow.md optimization (feature-020)
  - Session-start.sh trimming (feature-021)
  - Hook performance optimization (feature-022)
- Added v7.0.0 to changelog summary table

## Test plan
- [x] `bash tests/test-v7-metadata.sh` — 4/4 pass
- [x] All 5 test suites green (25/25 total tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)