### PR TITLE
fix(plugin): Add fix-plugin-cache.sh for stuck users

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,17 +653,24 @@ claude mcp add github -s user
 
 ### Stuck on Old Plugin Version
 
-If your project shows a version mismatch after updating the plugin:
+`claude plugin update` has a known bug where it doesn't re-download plugin files. Run this one-liner to fix it:
 
 ```bash
-claude plugin update claude-harness
+bash <(curl -sf https://raw.githubusercontent.com/panayiotism/claude-harness/main/fix-plugin-cache.sh)
 ```
 
-Then restart Claude Code and run `/claude-harness:setup` in your project to migrate project files.
+This updates the marketplace cache, downloads the latest plugin, and updates the registry. Then restart Claude Code and run `/claude-harness:setup`.
 
-**For plugin developers:** Use `./dev-mode.sh enable` to symlink the cache to your source repo for instant updates.
+**Note:** v8.1.0+ includes auto-update — the session-start hook automatically fixes stale caches on startup.
 
 ## Changelog
+
+### v8.1.0 (2026-02-15) - Auto-update stale plugin cache
+
+- session-start.sh auto-downloads latest plugin from GitHub when stale cache detected
+- Updates cache directory and `installed_plugins.json` registry automatically
+- Works around Claude Code `plugin update` bug (#19197, #14061, #13799, #15642)
+- Added `fix-plugin-cache.sh` curl-able script for users stuck on older versions
 
 ### v8.0.0 (2026-02-15) - Remove Agent Teams
 

--- a/fix-plugin-cache.sh
+++ b/fix-plugin-cache.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Claude Harness — Fix Stale Plugin Cache
+#
+# Fixes the known Claude Code bug where `claude plugin update` does not
+# re-download plugin files (#19197, #14061, #13799, #15642).
+#
+# This script:
+#   1. Updates the marketplace git cache (git pull)
+#   2. Downloads latest plugin source from GitHub
+#   3. Creates correct cache directory
+#   4. Updates installed_plugins.json registry
+#
+# Usage (run in your terminal, NOT inside Claude Code):
+#   bash <(curl -sf https://raw.githubusercontent.com/panayiotism/claude-harness/main/fix-plugin-cache.sh)
+
+set -euo pipefail
+
+REPO="panayiotism/claude-harness"
+PLUGIN_KEY="claude-harness@claude-harness"
+MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/claude-harness"
+CACHE_BASE="$HOME/.claude/plugins/cache/claude-harness/claude-harness"
+INSTALLED_PLUGINS="$HOME/.claude/plugins/installed_plugins.json"
+
+echo "=== Claude Harness: Fix Plugin Cache ==="
+echo ""
+
+# --- Prerequisites ---
+if [ ! -f "$INSTALLED_PLUGINS" ]; then
+    echo "Plugin not installed. Installing fresh..."
+    echo "  Run: claude plugin install claude-harness github:$REPO"
+    exit 1
+fi
+
+if ! command -v python3 &>/dev/null; then
+    echo "ERROR: python3 is required"; exit 1
+fi
+
+# --- Step 1: Update marketplace git cache ---
+if [ -d "$MARKETPLACE_DIR/.git" ]; then
+    echo "[1/4] Updating marketplace cache..."
+    (cd "$MARKETPLACE_DIR" && git fetch origin main 2>/dev/null && git reset --hard origin/main 2>/dev/null) \
+        && echo "  Marketplace updated." \
+        || echo "  WARN: Could not update marketplace (non-critical, continuing...)"
+else
+    echo "[1/4] No marketplace cache found (skipping)"
+fi
+
+# --- Step 2: Fetch latest version ---
+echo "[2/4] Checking latest version on GitHub..."
+
+LATEST_VERSION=""
+LATEST_SHA=""
+
+if command -v gh &>/dev/null; then
+    LATEST_VERSION=$(gh api "repos/$REPO/contents/claude-harness/.claude-plugin/plugin.json" \
+        --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | \
+        python3 -c "import json,sys; print(json.load(sys.stdin)['version'])" 2>/dev/null || true)
+    LATEST_SHA=$(gh api "repos/$REPO/commits/main" --jq '.sha' 2>/dev/null || true)
+fi
+
+if [ -z "$LATEST_VERSION" ]; then
+    LATEST_VERSION=$(curl -sf --max-time 10 \
+        "https://raw.githubusercontent.com/$REPO/main/claude-harness/.claude-plugin/plugin.json" 2>/dev/null | \
+        python3 -c "import json,sys; print(json.load(sys.stdin)['version'])" 2>/dev/null || true)
+fi
+
+if [ -z "$LATEST_SHA" ]; then
+    LATEST_SHA=$(curl -sf --max-time 10 \
+        "https://api.github.com/repos/$REPO/commits/main" 2>/dev/null | \
+        python3 -c "import json,sys; print(json.load(sys.stdin)['sha'])" 2>/dev/null || true)
+fi
+
+if [ -z "$LATEST_VERSION" ]; then
+    echo "ERROR: Could not fetch latest version from GitHub."
+    echo "Check your network connection and try again."
+    exit 1
+fi
+
+CURRENT_VERSION=$(python3 -c "
+import json
+with open('$INSTALLED_PLUGINS') as f:
+    data = json.load(f)
+p = data.get('plugins', {}).get('$PLUGIN_KEY', [])
+print(p[0].get('version', 'unknown') if p else 'not-installed')
+" 2>/dev/null || echo "unknown")
+
+echo "  Installed: v$CURRENT_VERSION"
+echo "  Latest:    v$LATEST_VERSION"
+
+if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+    echo ""
+    echo "Already up to date! No action needed."
+    exit 0
+fi
+
+# --- Step 3: Download and extract ---
+echo "[3/4] Downloading v$LATEST_VERSION..."
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+DOWNLOAD_OK=false
+if command -v gh &>/dev/null; then
+    gh api "repos/$REPO/tarball/main" > "$TMPDIR/repo.tar.gz" 2>/dev/null && DOWNLOAD_OK=true
+fi
+if [ "$DOWNLOAD_OK" = false ]; then
+    curl -sfL --max-time 60 "https://github.com/$REPO/archive/refs/heads/main.tar.gz" \
+        -o "$TMPDIR/repo.tar.gz" 2>/dev/null && DOWNLOAD_OK=true
+fi
+if [ "$DOWNLOAD_OK" = false ]; then
+    echo "ERROR: Could not download from GitHub"; exit 1
+fi
+
+tar -xzf "$TMPDIR/repo.tar.gz" -C "$TMPDIR"
+EXTRACTED_DIR=$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -type d | head -1)
+PLUGIN_SRC="$EXTRACTED_DIR/claude-harness"
+
+if [ ! -f "$PLUGIN_SRC/.claude-plugin/plugin.json" ]; then
+    echo "ERROR: Downloaded archive missing plugin.json"; exit 1
+fi
+
+# --- Step 4: Install to cache and update registry ---
+echo "[4/4] Installing to cache..."
+
+NEW_CACHE="$CACHE_BASE/$LATEST_VERSION"
+rm -rf "$NEW_CACHE" 2>/dev/null
+mkdir -p "$NEW_CACHE"
+cp -r "$PLUGIN_SRC/." "$NEW_CACHE/"
+chmod +x "$NEW_CACHE/hooks/"*.sh "$NEW_CACHE/setup.sh" 2>/dev/null || true
+
+# Update registry
+python3 -c "
+import json
+from datetime import datetime, timezone
+
+with open('$INSTALLED_PLUGINS') as f:
+    data = json.load(f)
+
+key = '$PLUGIN_KEY'
+plugins = data.get('plugins', {}).get(key, [])
+if plugins:
+    plugins[0]['installPath'] = '$NEW_CACHE'
+    plugins[0]['version'] = '$LATEST_VERSION'
+    if '$LATEST_SHA':
+        plugins[0]['gitCommitSha'] = '$LATEST_SHA'
+    plugins[0]['lastUpdated'] = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+else:
+    data.setdefault('plugins', {}).setdefault(key, []).append({
+        'scope': 'user',
+        'installPath': '$NEW_CACHE',
+        'version': '$LATEST_VERSION',
+        'installedAt': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+        'lastUpdated': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+        'gitCommitSha': '$LATEST_SHA'
+    })
+
+with open('$INSTALLED_PLUGINS', 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+"
+
+# Clear stale version check
+rm -f "$HOME/.claude/plugins/cache/claude-harness/.version-check" 2>/dev/null
+
+echo ""
+echo "=== Updated: v$CURRENT_VERSION -> v$LATEST_VERSION ==="
+echo ""
+echo "Next steps:"
+echo "  1. Restart Claude Code (exit all sessions)"
+echo "  2. Run /claude-harness:setup in your project"
+echo ""


### PR DESCRIPTION
## Summary
- Adds `fix-plugin-cache.sh` — a curl-able script that fixes stale plugin caches
- Updates the marketplace git cache, downloads latest source, updates registry
- Solves the chicken-and-egg: users stuck on v6.0.0 can't benefit from v8.1.0's auto-update
- Updates Troubleshooting section in README with correct instructions

## Usage
```bash
bash <(curl -sf https://raw.githubusercontent.com/panayiotism/claude-harness/main/fix-plugin-cache.sh)
```

## The full update strategy
| Scenario | Solution |
|---|---|
| User on v8.1.0+ with stale cache | Auto-update in session-start.sh handles it |
| User on v6.0.0 stuck | Run `fix-plugin-cache.sh` one-liner |
| Auto-update fails (no network) | Fallback instructions shown in session banner |

## Test plan
- [x] `bash -n fix-plugin-cache.sh` syntax check passes
- [ ] Run script from a machine with stale v6.0.0 cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)