### PR TITLE
feat(schemas): Add canonical JSON Schema files and fix version drift (v8.4.0)

### DIFF
--- a/.claude-harness/claude-progress.json
+++ b/.claude-harness/claude-progress.json
@@ -1,19 +1,21 @@
 {
-  "lastUpdated": "2026-02-15T12:00:00Z",
+  "lastUpdated": "2026-02-17T12:00:00Z",
   "currentProject": "claude-harness",
   "lastSession": {
-    "summary": "v8.1.0: Added auto-update to session-start.sh. When stale plugin cache detected, hook automatically downloads latest from GitHub, updates cache and registry. Falls back to uninstall/reinstall instructions if auto-update fails. Replaces broken claude plugin update command.",
+    "summary": "v8.4.0: Schema standardization. Added schemas/ directory with JSON Schema files for 5 key state files. Fixed loop-state version drift across commands. Removed hardcoded version comments from hooks. Added schema versioning convention to CLAUDE.md.",
     "completedTasks": [
-      "Added stale cache detection back to session-start.sh (lost in v8.0.0 rewrite)",
-      "Added auto_update_cache() that pulls from GitHub and updates plugin cache + registry",
-      "Fixed version check URL for v7.0.0+ subdirectory structure (claude-harness/ prefix)",
-      "Replaced broken 'claude plugin update' instructions with uninstall+reinstall fallback",
-      "Bumped version to 8.1.0"
+      "Created claude-harness/schemas/ with 5 JSON Schema files",
+      "Updated setup.md to reference schemas instead of inline examples",
+      "Fixed loop-state v4 reference in checkpoint.md to v8",
+      "Removed version comments from all 5 hook .sh files",
+      "Added schema versioning convention to CLAUDE.md",
+      "Updated procedural memory patterns for simplified version bumps"
     ],
     "blockers": [],
     "nextSteps": []
   },
   "recentChanges": [
+    "v8.4.0: Schema standardization — canonical schemas, version drift fixes, hook version cleanup",
     "v8.1.0: Auto-update stale plugin cache from session-start hook",
     "v8.0.0: Remove Agent Teams — direct implementation model",
     "v7.0.1: Add marketplace metadata description",

--- a/.claude-harness/memory/procedural/patterns.json
+++ b/.claude-harness/memory/procedural/patterns.json
@@ -17,8 +17,8 @@
       "source": "feature-005"
     },
     {
-      "pattern": "Version bump requires updating ALL files: plugin.json, .plugin-version, all hook version comments, README, setup.sh, claude-progress.json, and schema examples in command docs",
-      "source": "v5.0.0"
+      "pattern": "Version bump requires updating both plugin.json files and README changelog. Hook .sh files and command docs no longer embed version numbers — schemas/ is the canonical reference for data shapes",
+      "source": "v8.4.0"
     },
     {
       "pattern": "Use Grep with replace_all to find all occurrences of hardcoded values (like maxAttempts) across the codebase before updating",
@@ -29,8 +29,8 @@
       "source": "v5.0.0"
     },
     {
-      "pattern": "When migrating orchestration patterns, update ALL copies: commands/, .claude/commands/ (synced copy), setup.sh (file creation), README.md (docs + directory tree)",
-      "source": "v6.2.0"
+      "pattern": "Commands are served from plugin cache since v6.0 — only update commands/ in the plugin directory, not .claude/commands/",
+      "source": "v8.4.0"
     },
     {
       "pattern": "Critical behavioral instructions (like delegate mode) must be persisted to state files on disk and re-read at loop iteration points — conversation-only instructions are lost during context compaction",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-harness",
   "description": "Long-running agent harness with 5-layer memory architecture, GitHub integration, autonomous batch processing, 6 hooks (safety, quality gates), and 5 commands",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "author": {
     "name": "panayiotis"
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,9 @@ On every session start:
 ## Development Rules
 - Work on ONE feature at a time
 - Always update `.claude-harness/claude-progress.json` after completing work
-- Update version in both `.claude-plugin/plugin.json` and `claude-harness/.claude-plugin/plugin.json` for every change
+- Update version in both `.claude-plugin/plugin.json` and `claude-harness/.claude-plugin/plugin.json` for every change (these are the only version sources — `.plugin-version` is derived by setup.sh)
 - Update changelog in `README.md`
+- Do NOT add version numbers to hook `.sh` file comments — version lives only in plugin.json
 - Commit with descriptive messages
 - Leave codebase in clean, working state
 
@@ -39,6 +40,11 @@ On every session start:
   - Flags: `--no-merge` `--plan-only` `--autonomous` `--quick` `--fix`
 - `/claude-harness:checkpoint` - Manual commit + push + PR
 - `/claude-harness:merge` - Merge all PRs, auto-version, release
+
+## Schema Versioning Convention
+- The `"version"` field in JSON state files refers to the **data schema version**, not the plugin version
+- Increment schema version only when the shape of the data changes in a breaking way
+- Canonical schemas live in `claude-harness/schemas/*.schema.json` — reference these, don't embed inline examples
 
 ## Progress Tracking
 See: `.claude-harness/claude-progress.json` and `.claude-harness/features/active.json`

--- a/README.md
+++ b/README.md
@@ -665,6 +665,15 @@ This updates the marketplace cache, downloads the latest plugin, and updates the
 
 ## Changelog
 
+### v8.4.0 (2026-02-17) - Schema standardization
+
+- Added `claude-harness/schemas/` directory with JSON Schema files for key state files (loop-state, active-features, context, autonomous-state, memory-entries)
+- Fixed loop-state version drift: was referenced as v3 in setup.md, v4 in checkpoint.md, v8 in flow.md — now all reference canonical schema
+- Removed hardcoded version comments from hook `.sh` files (version lives only in plugin.json)
+- Added schema versioning convention to CLAUDE.md: `"version"` in JSON files = data schema version, not plugin version
+- Updated procedural memory patterns to reflect simplified version bump process
+- Command docs now reference schema files instead of embedding inline JSON examples
+
 ### v8.1.0 (2026-02-15) - Auto-update stale plugin cache
 
 - session-start.sh auto-downloads latest plugin from GitHub when stale cache detected
@@ -790,6 +799,7 @@ This is a critical hotfix. Users experiencing agent hangs should upgrade immedia
 
 | Version | Changes |
 |---------|---------|
+| **8.4.0** | **Schema Standardization**: Added `schemas/` directory with JSON Schema files for 5 key state files. Fixed loop-state version drift across commands. Removed hardcoded version comments from hooks. Added schema versioning convention to CLAUDE.md. |
 | **8.0.0** | **Remove Agent Teams**: Direct implementation model replaces 3-specialist team orchestration. Removed SubagentStart, TeammateIdle, TaskCompleted hooks. 9→6 hook registrations. No longer requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS. |
 | **7.0.0** | **Restructure repo for marketplace compatibility**: Moved plugin files into `claude-harness/` subdirectory. Fixes "not found in marketplace" install error and infinite recursion from self-referencing GitHub source. Marketplace source now `"./claude-harness"`. |
 | **6.0.6** | **Fix installation instructions**: README Quick Start used invalid `github:owner/repo` syntax. Replaced with correct marketplace workflow (add marketplace → install plugin). Added terminal CLI equivalent. |

--- a/claude-harness/.claude-plugin/plugin.json
+++ b/claude-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-harness",
   "description": "Long-running agent harness with 5-layer memory architecture, GitHub integration, autonomous batch processing, 6 hooks (safety, quality gates), and 5 commands",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "author": {
     "name": "panayiotis"
   }

--- a/claude-harness/commands/checkpoint.md
+++ b/claude-harness/commands/checkpoint.md
@@ -233,17 +233,14 @@ Create a checkpoint of the current session:
        - Call `TaskList` to find feature's tasks
        - For any tasks not yet "completed", call `TaskUpdate` to mark as "completed"
        - Report: "All 5 tasks completed"
-     - Reset loop state to idle (v4 schema):
+     - Reset loop state to idle (see `schemas/loop-state.schema.json` for canonical shape):
        ```json
        {
-         "version": 4,
+         "version": 8,
          "feature": null,
          "featureName": null,
          "type": "feature",
-         "linkedTo": {
-           "featureId": null,
-           "featureName": null
-         },
+         "linkedTo": null,
          "status": "idle",
          "attempt": 0,
          "maxAttempts": 15,

--- a/claude-harness/commands/setup.md
+++ b/claude-harness/commands/setup.md
@@ -73,111 +73,18 @@ This command automatically detects what needs to be done:
 
 ## File Schemas
 
-### sessions/{session-id}/context.json (created at runtime)
-```json
-{
-  "version": 3,
-  "computedAt": null,
-  "sessionId": null,
-  "activeFeature": null,
-  "relevantMemory": {
-    "recentDecisions": [],
-    "projectPatterns": [],
-    "avoidApproaches": [],
-    "learnedRules": []
-  },
-  "currentTask": null,
-  "compilationLog": []
-}
-```
+Canonical schemas are defined in the plugin's `schemas/` directory (JSON Schema format). Key state files:
 
-### sessions/{session-id}/loop-state.json (created at runtime)
-```json
-{
-  "version": 3,
-  "feature": null,
-  "featureName": null,
-  "type": "feature",
-  "linkedTo": null,
-  "status": "idle",
-  "attempt": 0,
-  "maxAttempts": 15,
-  "startedAt": null,
-  "lastAttemptAt": null,
-  "verification": {},
-  "history": []
-}
-```
+| File | Schema | Created By |
+|------|--------|------------|
+| `sessions/{id}/context.json` | `schemas/context.schema.json` (v3) | Phase 1 context compilation |
+| `sessions/{id}/loop-state.json` | `schemas/loop-state.schema.json` (v8) | Phase 4 implementation |
+| `sessions/{id}/autonomous-state.json` | `schemas/autonomous-state.schema.json` (v3) | `--autonomous` mode |
+| `features/active.json` | `schemas/active-features.schema.json` (v3) | Phase 2 feature creation |
+| `memory/procedural/failures.json` | `schemas/memory-entries.schema.json` (v3) | Verification failures |
+| `memory/procedural/successes.json` | `schemas/memory-entries.schema.json` (v3) | Verification passes |
 
-### memory/episodic/decisions.json
-```json
-{
-  "maxEntries": 50,
-  "entries": []
-}
-```
-
-### memory/semantic/architecture.json
-```json
-{
-  "projectType": null,
-  "techStack": {},
-  "structure": {
-    "entryPoints": [],
-    "components": [],
-    "api": [],
-    "tests": []
-  },
-  "patterns": {},
-  "discoveredAt": "<current timestamp>",
-  "lastUpdated": "<current timestamp>"
-}
-```
-
-### memory/procedural/failures.json
-```json
-{
-  "entries": []
-}
-```
-
-### memory/procedural/successes.json
-```json
-{
-  "entries": []
-}
-```
-
-### features/active.json
-```json
-{
-  "features": []
-}
-```
-
-
-### agents/context.json
-```json
-{
-  "version": 1,
-  "currentSession": null,
-  "agentResults": []
-}
-```
-
-### claude-progress.json
-```json
-{
-  "lastUpdated": "<current timestamp>",
-  "currentProject": "<directory name>",
-  "lastSession": {
-    "summary": "Initial harness setup",
-    "completedTasks": [],
-    "blockers": [],
-    "nextSteps": ["Run /claude-harness:start to begin"]
-  }
-}
-```
+All other memory files (episodic, semantic, learned) use v3 schemas as created by `setup.sh`.
 
 ## After Setup
 

--- a/claude-harness/hooks/permission-request.sh
+++ b/claude-harness/hooks/permission-request.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Harness PermissionRequest Hook v7.0.0
+# Claude Harness PermissionRequest Hook
 # Autonomous mode acceleration — auto-approve safe ops, auto-deny destructive
 # No matcher — fires for all permission requests
 # No-op when not in autonomous mode

--- a/claude-harness/hooks/pre-compact.sh
+++ b/claude-harness/hooks/pre-compact.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Harness PreCompact Hook v7.0.0
+# Claude Harness PreCompact Hook
 # Saves critical state before context compaction to prevent data loss
 # This is a safety net - ideally users run /claude-harness:checkpoint then /clear
 

--- a/claude-harness/hooks/pre-tool-use.sh
+++ b/claude-harness/hooks/pre-tool-use.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Harness PreToolUse Hook v7.0.0
+# Claude Harness PreToolUse Hook
 # Branch safety + state protection
 # Matchers: "Bash" and "Edit|Write" (registered separately in hooks.json)
 # Exit 0 with permissionDecision: "deny" = block the tool call

--- a/claude-harness/hooks/session-start.sh
+++ b/claude-harness/hooks/session-start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Claude Harness SessionStart Hook v8.3.0
+# Claude Harness SessionStart Hook
 
 HARNESS_DIR="$CLAUDE_PROJECT_DIR/.claude-harness"
 [ ! -d "$HARNESS_DIR" ] && exit 0

--- a/claude-harness/hooks/stop.sh
+++ b/claude-harness/hooks/stop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Stop Hook v8.0.0 - Detect completion, mark active sessions on natural stop
+# Stop Hook - Detect completion, mark active sessions on natural stop
 # Runs when Claude finishes responding (NOT on user interrupt - Ctrl+C/Escape)
 # Within 5-second timeout (hooks.json)
 

--- a/claude-harness/schemas/active-features.schema.json
+++ b/claude-harness/schemas/active-features.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "active-features.schema.json",
+  "title": "Active Features",
+  "description": "Feature and fix registry at .claude-harness/features/active.json",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": 3,
+      "description": "Schema version (data shape version, not plugin version)"
+    },
+    "features": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/feature" }
+    },
+    "fixes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/fix" }
+    }
+  },
+  "required": ["version", "features", "fixes"],
+  "$defs": {
+    "feature": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "pattern": "^feature-\\d+$" },
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "priority": { "type": "integer", "minimum": 1 },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "needs_tests", "in_progress", "passing", "failing", "blocked", "escalated"]
+        },
+        "phase": {
+          "type": ["string", "null"],
+          "enum": ["planning", "test_generation", "implementation", "verification", null]
+        },
+        "verification": { "$ref": "#/$defs/verificationCommands" },
+        "attempts": { "type": "integer", "minimum": 0 },
+        "maxAttempts": { "type": "integer", "default": 15 },
+        "relatedFiles": { "type": "array", "items": { "type": "string" } },
+        "github": { "$ref": "#/$defs/githubRefs" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "required": ["id", "name", "status"]
+    },
+    "fix": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "pattern": "^fix-feature-\\d+-\\d+$" },
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "linkedTo": {
+          "type": "object",
+          "properties": {
+            "featureId": { "type": "string" },
+            "featureName": { "type": "string" },
+            "issueNumber": { "type": ["integer", "null"] }
+          },
+          "required": ["featureId"]
+        },
+        "type": { "const": "bugfix" },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "in_progress", "passing", "escalated"]
+        },
+        "verification": { "$ref": "#/$defs/verificationCommands" },
+        "attempts": { "type": "integer", "minimum": 0 },
+        "maxAttempts": { "type": "integer", "default": 15 },
+        "relatedFiles": { "type": "array", "items": { "type": "string" } },
+        "github": { "$ref": "#/$defs/githubRefs" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "required": ["id", "name", "linkedTo", "status"]
+    },
+    "verificationCommands": {
+      "type": "object",
+      "properties": {
+        "build": { "type": ["string", "null"] },
+        "tests": { "type": ["string", "null"] },
+        "lint": { "type": ["string", "null"] },
+        "typecheck": { "type": ["string", "null"] },
+        "acceptance": { "type": ["string", "null"] },
+        "custom": { "type": "array", "items": { "type": "string" } },
+        "inherited": { "type": "boolean" }
+      }
+    },
+    "githubRefs": {
+      "type": "object",
+      "properties": {
+        "issueNumber": { "type": ["integer", "null"] },
+        "prNumber": { "type": ["integer", "null"] },
+        "branch": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/claude-harness/schemas/autonomous-state.schema.json
+++ b/claude-harness/schemas/autonomous-state.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "autonomous-state.schema.json",
+  "title": "Autonomous State",
+  "description": "Batch processing state at .claude-harness/sessions/{session-id}/autonomous-state.json",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": 3,
+      "description": "Schema version (data shape version, not plugin version)"
+    },
+    "mode": {
+      "const": "autonomous"
+    },
+    "startedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "maxIterations": {
+      "type": "integer",
+      "default": 20
+    },
+    "consecutiveFailures": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "maxConsecutiveFailures": {
+      "type": "integer",
+      "default": 3
+    },
+    "completedFeatures": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "skippedFeatures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    },
+    "failedFeatures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "reason": { "type": "string" },
+          "attempts": { "type": "integer" }
+        }
+      }
+    },
+    "currentFeature": {
+      "type": ["string", "null"]
+    }
+  },
+  "required": ["version", "mode", "startedAt", "iteration", "maxIterations", "currentFeature"]
+}

--- a/claude-harness/schemas/context.schema.json
+++ b/claude-harness/schemas/context.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "context.schema.json",
+  "title": "Session Context",
+  "description": "Compiled working context at .claude-harness/sessions/{session-id}/context.json",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": 3,
+      "description": "Schema version (data shape version, not plugin version)"
+    },
+    "computedAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "sessionId": {
+      "type": ["string", "null"]
+    },
+    "github": {
+      "type": "object",
+      "properties": {
+        "owner": { "type": "string" },
+        "repo": { "type": "string" }
+      }
+    },
+    "activeFeature": {
+      "type": ["string", "null"],
+      "description": "Currently active feature or fix ID"
+    },
+    "relevantMemory": {
+      "type": "object",
+      "properties": {
+        "recentDecisions": { "type": "array" },
+        "projectPatterns": { "type": "array" },
+        "avoidApproaches": { "type": "array" },
+        "learnedRules": { "type": "array" }
+      }
+    },
+    "currentTask": {
+      "type": ["object", "null"]
+    },
+    "compilationLog": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["version", "sessionId", "relevantMemory"]
+}

--- a/claude-harness/schemas/loop-state.schema.json
+++ b/claude-harness/schemas/loop-state.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "loop-state.schema.json",
+  "title": "Loop State",
+  "description": "Agentic loop state for feature/fix implementation. Session-scoped at .claude-harness/sessions/{session-id}/loop-state.json",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": 8,
+      "description": "Schema version (data shape version, not plugin version)"
+    },
+    "feature": {
+      "type": ["string", "null"],
+      "description": "Feature or fix ID (e.g. 'feature-001', 'fix-feature-001-001')"
+    },
+    "featureName": {
+      "type": ["string", "null"],
+      "description": "Human-readable feature description"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["feature", "fix"],
+      "default": "feature"
+    },
+    "linkedTo": {
+      "type": ["object", "null"],
+      "description": "Parent feature reference (for fixes only)",
+      "properties": {
+        "featureId": { "type": ["string", "null"] },
+        "featureName": { "type": ["string", "null"] }
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["idle", "pending", "in_progress", "completed", "escalated", "needs_review"]
+    },
+    "attempt": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "maxAttempts": {
+      "type": "integer",
+      "default": 15
+    },
+    "startedAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "lastAttemptAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "phase": {
+      "type": ["string", "null"],
+      "enum": ["research", "plan", "implement", "verify", "accept", "checkpoint", null]
+    },
+    "verification": {
+      "type": "object",
+      "description": "Last verification results keyed by command name"
+    },
+    "history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "attempt": { "type": "integer" },
+          "approach": { "type": "string" },
+          "result": { "type": "string", "enum": ["success", "failure"] },
+          "errors": { "type": "array", "items": { "type": "string" } },
+          "rootCause": { "type": "string" }
+        }
+      }
+    },
+    "tasks": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "chain": { "type": "array", "items": { "type": "string" } },
+        "current": { "type": ["string", "null"] },
+        "completed": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "lastCheckpoint": {
+      "type": ["string", "null"],
+      "description": "Commit hash of last checkpoint"
+    },
+    "escalationRequested": {
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "required": ["version", "feature", "status", "attempt", "maxAttempts", "history"]
+}

--- a/claude-harness/schemas/memory-entries.schema.json
+++ b/claude-harness/schemas/memory-entries.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "memory-entries.schema.json",
+  "title": "Procedural Memory Entries",
+  "description": "Shared schema for failures.json and successes.json in .claude-harness/memory/procedural/",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": 3,
+      "description": "Schema version (data shape version, not plugin version)"
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/failureEntry" },
+          { "$ref": "#/$defs/successEntry" }
+        ]
+      }
+    }
+  },
+  "required": ["entries"],
+  "$defs": {
+    "failureEntry": {
+      "type": "object",
+      "description": "Used in memory/procedural/failures.json",
+      "properties": {
+        "id": { "type": "string", "description": "Format: fail-YYYYMMDD-NNN" },
+        "timestamp": { "type": "string", "format": "date-time" },
+        "feature": { "type": "string" },
+        "type": { "type": "string", "enum": ["feature", "fix", "orchestration"] },
+        "linkedTo": { "type": ["string", "null"] },
+        "approach": { "type": "string", "description": "What was attempted" },
+        "agent": { "type": "string", "description": "Agent name (for orchestration type)" },
+        "files": { "type": "array", "items": { "type": "string" } },
+        "errors": { "type": "array", "items": { "type": "string" } },
+        "rootCause": { "type": "string" },
+        "prevention": { "type": "string", "description": "How to avoid this in the future" }
+      },
+      "required": ["id", "timestamp", "feature", "approach", "errors"]
+    },
+    "successEntry": {
+      "type": "object",
+      "description": "Used in memory/procedural/successes.json",
+      "properties": {
+        "id": { "type": "string", "description": "Format: suc-YYYYMMDD-NNN" },
+        "timestamp": { "type": "string", "format": "date-time" },
+        "feature": { "type": "string" },
+        "type": { "type": "string", "enum": ["feature", "fix", "orchestration"] },
+        "linkedTo": { "type": ["string", "null"] },
+        "approach": { "type": "string", "description": "What was done" },
+        "agent": { "type": "string", "description": "Agent name (for orchestration type)" },
+        "files": { "type": "array", "items": { "type": "string" } },
+        "verificationResults": { "type": "object" },
+        "patterns": { "type": "array", "items": { "type": "string" }, "description": "Reusable patterns extracted" },
+        "lessons": { "type": "array", "items": { "type": "string" }, "description": "Lessons learned" }
+      },
+      "required": ["id", "timestamp", "feature", "approach"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added `claude-harness/schemas/` directory with 5 JSON Schema files as canonical reference for state file shapes
- Fixed loop-state version drift (referenced as v3, v4, and v8 across different commands — now unified at v8)
- Removed hardcoded version comments from all 5 hook `.sh` files (version lives only in plugin.json)
- Added schema versioning convention to CLAUDE.md
- Updated procedural memory patterns for simplified version bump process

## Context
Research into GitHub Spec-Kit and Fission-AI OpenSpec revealed that while neither framework should be adopted (wrong problem domain, wrong user model, dependency issues), three internal improvements were worth making: schema standardization, version deduplication, and a versioning convention.

## Test plan
- [ ] Verify `setup.sh` still creates files matching the schemas
- [ ] Verify `session-start.sh` still reads state correctly (no version comment dependency)
- [ ] Verify hook scripts still function after comment removal
- [ ] Verify `flow.md` phase references remain consistent with schema files

🤖 Generated with [Claude Code](https://claude.com/claude-code)