### PR TITLE
fix(hooks): Harden JSON parsing with jq, add error traps

### DIFF
--- a/.claude-harness/features/active.json
+++ b/.claude-harness/features/active.json
@@ -315,6 +315,55 @@
       "createdAt": "2026-02-18T12:00:00.000Z",
       "updatedAt": "2026-02-18T12:00:00.000Z"
     }
+    ,
+    {
+      "id": "feature-008",
+      "name": "Harden hook JSON parsing and error handling",
+      "description": "Fix PreToolUse:Bash hook errors by switching from fragile grep-based JSON parsing to jq, adding error traps, and fixing pre-compact invalid JSON generation.",
+      "priority": 0,
+      "status": "in_progress",
+      "acceptanceCriteria": [
+        {
+          "scenario": "Hook handles commands with escaped quotes",
+          "given": "a Bash tool call with command containing escaped double quotes",
+          "when": "the PreToolUse hook processes the input",
+          "then": "it correctly extracts the command and evaluates safety rules"
+        },
+        {
+          "scenario": "Hook handles commands with embedded JSON",
+          "given": "a Bash tool call with a curl command containing JSON body",
+          "when": "the PreToolUse hook processes the input",
+          "then": "it correctly parses tool_name and command without error"
+        },
+        {
+          "scenario": "Hook always exits 0 on unexpected errors",
+          "given": "an unexpected condition (missing env var, malformed input)",
+          "when": "the PreToolUse hook runs",
+          "then": "it exits 0 (allowing the tool call) rather than erroring"
+        },
+        {
+          "scenario": "Pre-compact generates valid JSON with empty state",
+          "given": "no active loop state or working context",
+          "when": "the PreCompact hook creates a backup",
+          "then": "the backup JSON file is valid (parseable by jq)"
+        }
+      ],
+      "verification": {
+        "build": null,
+        "tests": "bash -n hooks/pre-tool-use && bash -n hooks/permission-request && bash -n hooks/pre-compact",
+        "lint": null,
+        "typecheck": null,
+        "acceptance": null
+      },
+      "relatedFiles": ["hooks/pre-tool-use", "hooks/permission-request", "hooks/pre-compact"],
+      "github": {
+        "issueNumber": 52,
+        "prNumber": null,
+        "branch": "feature/feature-008"
+      },
+      "createdAt": "2026-02-27T12:30:00.000Z",
+      "updatedAt": "2026-02-27T12:30:00.000Z"
+    }
   ],
   "fixes": []
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-harness",
   "description": "Long-running agent harness with 5-layer memory architecture, GitHub integration, autonomous batch processing, Agent Teams with ATDD, 9 hooks (safety, quality gates, team coordination), and 6 commands",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "author": {
     "name": "panayiotis"
   }

--- a/README.md
+++ b/README.md
@@ -673,6 +673,13 @@ Then restart Claude Code and run `/claude-harness:setup`.
 
 ## Changelog
 
+### v10.0.4 (2026-02-27) - Harden hook JSON parsing and error handling
+
+- **Fix: PreToolUse:Bash hook errors**: Replaced fragile `grep -o "[^"]*"` JSON parsing with `jq` in `pre-tool-use`, `permission-request`, and `pre-compact` hooks. The grep patterns broke on commands containing escaped quotes (e.g., `git commit -m "feat: something"`), causing hook errors in Claude Code.
+- **Fix: Pre-compact invalid JSON**: The `pre-compact` hook generated invalid JSON (`"loopState": ,`) when state variables were empty. Now defaults to `null` and uses `jq` for safe JSON construction.
+- **Safety net**: Added `trap 'exit 0' ERR` to all three hooks, ensuring they never exit non-zero (which triggers "hook error" in Claude Code). Hooks should always allow tool calls on unexpected errors rather than blocking.
+- **Consistency**: Replaced all `echo "$VAR"` with `printf '%s' "$VAR"` to avoid escape sequence interpretation issues.
+
 ### v10.0.3 (2026-02-27) - Auto-run setup on session start
 
 - **Auto-migrations on session start**: `setup.sh` now runs automatically from the SessionStart hook when `.claude-harness/` already exists. This applies migrations, creates missing state files, and cleans up legacy artifacts transparently — no need to re-run `/claude-harness:setup` after plugin updates. First-time setup still requires explicit `/claude-harness:setup`.

--- a/hooks/permission-request
+++ b/hooks/permission-request
@@ -4,6 +4,9 @@
 # No matcher — fires for all permission requests
 # No-op when not in autonomous mode
 
+# Safety net: ensure hook NEVER exits non-zero
+trap 'exit 0' ERR
+
 HARNESS_DIR="$CLAUDE_PROJECT_DIR/.claude-harness"
 
 # Skip if not a harness project
@@ -38,8 +41,63 @@ fi
 
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
-COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
+# Parse JSON with jq (reliable) or grep fallback
+if command -v jq >/dev/null 2>&1; then
+    TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || TOOL_NAME=""
+    COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || COMMAND=""
+else
+    TOOL_NAME=$(printf '%s' "$INPUT" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/') || TOOL_NAME=""
+    COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/') || COMMAND=""
+fi
+
+# Helper: output permission decision JSON
+emit_decision() {
+    local BEHAVIOR="$1"
+    local MESSAGE="${2:-}"
+    if command -v jq >/dev/null 2>&1; then
+        if [ -n "$MESSAGE" ]; then
+            jq -n --arg b "$BEHAVIOR" --arg m "$MESSAGE" '{
+                hookSpecificOutput: {
+                    hookEventName: "PermissionRequest",
+                    decision: { behavior: $b, message: $m }
+                }
+            }'
+        else
+            jq -n --arg b "$BEHAVIOR" '{
+                hookSpecificOutput: {
+                    hookEventName: "PermissionRequest",
+                    decision: { behavior: $b }
+                }
+            }'
+        fi
+    else
+        if [ -n "$MESSAGE" ]; then
+            SAFE_MSG=$(printf '%s' "$MESSAGE" | sed 's/"/\\"/g')
+            cat << EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "$BEHAVIOR",
+      "message": "$SAFE_MSG"
+    }
+  }
+}
+EOF
+        else
+            cat << EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "$BEHAVIOR"
+    }
+  }
+}
+EOF
+        fi
+    fi
+}
 
 # ============================================================================
 # DENY LIST — block even in autonomous mode
@@ -47,50 +105,20 @@ COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | 
 
 if [ "$TOOL_NAME" = "Bash" ] && [ -n "$COMMAND" ]; then
     # Force push
-    if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force'; then
-        cat << EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PermissionRequest",
-    "decision": {
-      "behavior": "deny",
-      "message": "AUTONOMOUS DENY: git push --force is destructive even in autonomous mode."
-    }
-  }
-}
-EOF
+    if printf '%s' "$COMMAND" | grep -qE 'git\s+push\s+.*--force'; then
+        emit_decision "deny" "AUTONOMOUS DENY: git push --force is destructive even in autonomous mode."
         exit 0
     fi
 
     # Reset hard
-    if echo "$COMMAND" | grep -qE 'git\s+reset\s+--hard'; then
-        cat << EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PermissionRequest",
-    "decision": {
-      "behavior": "deny",
-      "message": "AUTONOMOUS DENY: git reset --hard discards changes."
-    }
-  }
-}
-EOF
+    if printf '%s' "$COMMAND" | grep -qE 'git\s+reset\s+--hard'; then
+        emit_decision "deny" "AUTONOMOUS DENY: git reset --hard discards changes."
         exit 0
     fi
 
     # Broad rm -rf
-    if echo "$COMMAND" | grep -qE 'rm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+(/|~|\.\.)'; then
-        cat << EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PermissionRequest",
-    "decision": {
-      "behavior": "deny",
-      "message": "AUTONOMOUS DENY: Broad rm -rf is too destructive."
-    }
-  }
-}
-EOF
+    if printf '%s' "$COMMAND" | grep -qE 'rm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+(/|~|\.\.)'; then
+        emit_decision "deny" "AUTONOMOUS DENY: Broad rm -rf is too destructive."
         exit 0
     fi
 fi
@@ -103,85 +131,65 @@ if [ "$TOOL_NAME" = "Bash" ] && [ -n "$COMMAND" ]; then
     ALLOW=false
 
     # Read-only git operations
-    if echo "$COMMAND" | grep -qE '^git\s+(status|log|diff|branch|show|rev-parse|describe|remote|fetch)\b'; then
+    if printf '%s' "$COMMAND" | grep -qE '^git\s+(status|log|diff|branch|show|rev-parse|describe|remote|fetch)\b'; then
         ALLOW=true
     fi
 
     # Safe git operations on feature branches
-    if echo "$COMMAND" | grep -qE '^git\s+(add|commit|stash)\b'; then
+    if printf '%s' "$COMMAND" | grep -qE '^git\s+(add|commit|stash)\b'; then
         ALLOW=true
     fi
 
     # Non-force, non-main push
-    if echo "$COMMAND" | grep -qE '^git\s+push\b' && \
-       ! echo "$COMMAND" | grep -qE '(--force|origin\s+(main|master)\b)'; then
+    if printf '%s' "$COMMAND" | grep -qE '^git\s+push\b' && \
+       ! printf '%s' "$COMMAND" | grep -qE '(--force|origin\s+(main|master)\b)'; then
         ALLOW=true
     fi
 
     # Test/build/lint commands from config
     CONFIG_FILE="$HARNESS_DIR/config.json"
     if [ -f "$CONFIG_FILE" ]; then
-        TEST_CMD=$(python3 -c "import json; c=json.load(open('$CONFIG_FILE')); print(c.get('verification',{}).get('tests',''))" 2>/dev/null)
-        BUILD_CMD=$(python3 -c "import json; c=json.load(open('$CONFIG_FILE')); print(c.get('verification',{}).get('build',''))" 2>/dev/null)
-        LINT_CMD=$(python3 -c "import json; c=json.load(open('$CONFIG_FILE')); print(c.get('verification',{}).get('lint',''))" 2>/dev/null)
-        TC_CMD=$(python3 -c "import json; c=json.load(open('$CONFIG_FILE')); print(c.get('verification',{}).get('typecheck',''))" 2>/dev/null)
+        if command -v jq >/dev/null 2>&1; then
+            TEST_CMD=$(jq -r '.verification.tests // empty' "$CONFIG_FILE" 2>/dev/null) || TEST_CMD=""
+            BUILD_CMD=$(jq -r '.verification.build // empty' "$CONFIG_FILE" 2>/dev/null) || BUILD_CMD=""
+            LINT_CMD=$(jq -r '.verification.lint // empty' "$CONFIG_FILE" 2>/dev/null) || LINT_CMD=""
+            TC_CMD=$(jq -r '.verification.typecheck // empty' "$CONFIG_FILE" 2>/dev/null) || TC_CMD=""
+        elif command -v python3 >/dev/null 2>&1; then
+            TEST_CMD=$(python3 -c "import json; c=json.load(open('$CONFIG_FILE')); print(c.get('verification',{}).get('tests',''))" 2>/dev/null) || TEST_CMD=""
+            BUILD_CMD=$(python3 -c "import json; c=json.load(open('$CONFIG_FILE')); print(c.get('verification',{}).get('build',''))" 2>/dev/null) || BUILD_CMD=""
+            LINT_CMD=$(python3 -c "import json; c=json.load(open('$CONFIG_FILE')); print(c.get('verification',{}).get('lint',''))" 2>/dev/null) || LINT_CMD=""
+            TC_CMD=$(python3 -c "import json; c=json.load(open('$CONFIG_FILE')); print(c.get('verification',{}).get('typecheck',''))" 2>/dev/null) || TC_CMD=""
+        fi
 
-        [ -n "$TEST_CMD" ] && echo "$COMMAND" | grep -qF "$TEST_CMD" && ALLOW=true
-        [ -n "$BUILD_CMD" ] && echo "$COMMAND" | grep -qF "$BUILD_CMD" && ALLOW=true
-        [ -n "$LINT_CMD" ] && echo "$COMMAND" | grep -qF "$LINT_CMD" && ALLOW=true
-        [ -n "$TC_CMD" ] && echo "$COMMAND" | grep -qF "$TC_CMD" && ALLOW=true
+        [ -n "$TEST_CMD" ] && printf '%s' "$COMMAND" | grep -qF "$TEST_CMD" && ALLOW=true
+        [ -n "$BUILD_CMD" ] && printf '%s' "$COMMAND" | grep -qF "$BUILD_CMD" && ALLOW=true
+        [ -n "$LINT_CMD" ] && printf '%s' "$COMMAND" | grep -qF "$LINT_CMD" && ALLOW=true
+        [ -n "$TC_CMD" ] && printf '%s' "$COMMAND" | grep -qF "$TC_CMD" && ALLOW=true
     fi
 
     # Package managers (install only)
-    if echo "$COMMAND" | grep -qE '^(npm|yarn|pnpm)\s+install\b'; then
+    if printf '%s' "$COMMAND" | grep -qE '^(npm|yarn|pnpm)\s+install\b'; then
         ALLOW=true
     fi
-    if echo "$COMMAND" | grep -qE '^pip\s+install\b'; then
+    if printf '%s' "$COMMAND" | grep -qE '^pip\s+install\b'; then
         ALLOW=true
     fi
 
     if [ "$ALLOW" = true ]; then
-        cat << EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PermissionRequest",
-    "decision": {
-      "behavior": "allow"
-    }
-  }
-}
-EOF
+        emit_decision "allow"
         exit 0
     fi
 fi
 
 # For Edit/Write tools — auto-approve in autonomous mode (PreToolUse handles safety)
 if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
-    cat << EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PermissionRequest",
-    "decision": {
-      "behavior": "allow"
-    }
-  }
-}
-EOF
+    emit_decision "allow"
     exit 0
 fi
 
 # For Read/Glob/Grep — auto-approve (read-only)
 if [ "$TOOL_NAME" = "Read" ] || [ "$TOOL_NAME" = "Glob" ] || [ "$TOOL_NAME" = "Grep" ]; then
-    cat << EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PermissionRequest",
-    "decision": {
-      "behavior": "allow"
-    }
-  }
-}
-EOF
+    emit_decision "allow"
     exit 0
 fi
 

--- a/hooks/pre-compact
+++ b/hooks/pre-compact
@@ -3,6 +3,9 @@
 # Saves critical state before context compaction to prevent data loss
 # This is a safety net - ideally users run /claude-harness:checkpoint then /clear
 
+# Safety net: ensure hook NEVER exits non-zero
+trap 'exit 0' ERR
+
 HARNESS_DIR="$CLAUDE_PROJECT_DIR/.claude-harness"
 
 # Skip if not a harness project
@@ -24,42 +27,75 @@ mkdir -p "$BACKUP_DIR"
 # Generate backup filename with timestamp
 BACKUP_FILE="$BACKUP_DIR/pre-compact-$(date +%Y%m%d-%H%M%S).json"
 
-# Gather current state
-LOOP_STATE=""
+# Gather current state (default to null for valid JSON)
+LOOP_STATE="null"
 if [ -f "$HARNESS_DIR/loops/state.json" ]; then
-    LOOP_STATE=$(cat "$HARNESS_DIR/loops/state.json" 2>/dev/null)
+    # Validate JSON before embedding; fall back to null
+    if command -v jq >/dev/null 2>&1; then
+        LOOP_STATE=$(jq '.' "$HARNESS_DIR/loops/state.json" 2>/dev/null) || LOOP_STATE="null"
+    else
+        LOOP_STATE=$(cat "$HARNESS_DIR/loops/state.json" 2>/dev/null) || LOOP_STATE="null"
+    fi
 fi
 
-WORKING_CONTEXT=""
+WORKING_CONTEXT="null"
 if [ -f "$HARNESS_DIR/memory/working/context.json" ]; then
-    WORKING_CONTEXT=$(cat "$HARNESS_DIR/memory/working/context.json" 2>/dev/null)
+    if command -v jq >/dev/null 2>&1; then
+        WORKING_CONTEXT=$(jq '.' "$HARNESS_DIR/memory/working/context.json" 2>/dev/null) || WORKING_CONTEXT="null"
+    else
+        WORKING_CONTEXT=$(cat "$HARNESS_DIR/memory/working/context.json" 2>/dev/null) || WORKING_CONTEXT="null"
+    fi
 fi
 
-PROGRESS=""
+PROGRESS="null"
 if [ -f "$HARNESS_DIR/claude-progress.json" ]; then
-    PROGRESS=$(cat "$HARNESS_DIR/claude-progress.json" 2>/dev/null)
+    if command -v jq >/dev/null 2>&1; then
+        PROGRESS=$(jq '.' "$HARNESS_DIR/claude-progress.json" 2>/dev/null) || PROGRESS="null"
+    else
+        PROGRESS=$(cat "$HARNESS_DIR/claude-progress.json" 2>/dev/null) || PROGRESS="null"
+    fi
 fi
 
 # Get git status for context
 GIT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
 GIT_STATUS=$(git status --porcelain 2>/dev/null | head -20)
 GIT_LAST_COMMIT=$(git log -1 --format="%h %s" 2>/dev/null || echo "unknown")
+UNCOMMITTED_COUNT=$(printf '%s' "$GIT_STATUS" | grep -c '.' 2>/dev/null || echo "0")
 
-# Create backup JSON
-cat > "$BACKUP_FILE" << BACKUP_EOF
+# Create backup JSON using jq if available for safety
+if command -v jq >/dev/null 2>&1; then
+    jq -n \
+        --arg ts "$TIMESTAMP" \
+        --arg branch "$GIT_BRANCH" \
+        --arg commit "$GIT_LAST_COMMIT" \
+        --argjson files "$UNCOMMITTED_COUNT" \
+        --argjson loop "$LOOP_STATE" \
+        --argjson working "$WORKING_CONTEXT" \
+        --argjson progress "$PROGRESS" \
+        '{
+            timestamp: $ts,
+            reason: "pre-compaction-safety-backup",
+            git: { branch: $branch, lastCommit: $commit, uncommittedFiles: $files },
+            loopState: $loop,
+            workingContext: $working,
+            progress: $progress
+        }' > "$BACKUP_FILE" 2>/dev/null
+else
+    cat > "$BACKUP_FILE" << BACKUP_EOF
 {
   "timestamp": "$TIMESTAMP",
   "reason": "pre-compaction-safety-backup",
   "git": {
     "branch": "$GIT_BRANCH",
     "lastCommit": "$GIT_LAST_COMMIT",
-    "uncommittedFiles": $(echo "$GIT_STATUS" | wc -l)
+    "uncommittedFiles": $UNCOMMITTED_COUNT
   },
   "loopState": $LOOP_STATE,
   "workingContext": $WORKING_CONTEXT,
   "progress": $PROGRESS
 }
 BACKUP_EOF
+fi
 
 # Keep only last 5 backups to avoid bloat
 ls -t "$BACKUP_DIR"/pre-compact-*.json 2>/dev/null | tail -n +6 | xargs rm -f 2>/dev/null
@@ -70,12 +106,13 @@ ls -t "$BACKUP_DIR"/pre-compact-*.json 2>/dev/null | tail -n +6 | xargs rm -f 2>
 
 # Add compaction event to progress if file exists
 if [ -f "$HARNESS_DIR/claude-progress.json" ]; then
-    # Use a simple approach - just note that compaction happened
     TEMP_FILE=$(mktemp)
-    if command -v jq &> /dev/null; then
+    if command -v jq >/dev/null 2>&1; then
         jq --arg ts "$TIMESTAMP" '.lastCompaction = $ts | .compactionCount = ((.compactionCount // 0) + 1)' \
             "$HARNESS_DIR/claude-progress.json" > "$TEMP_FILE" 2>/dev/null && \
             mv "$TEMP_FILE" "$HARNESS_DIR/claude-progress.json"
+    else
+        rm -f "$TEMP_FILE"
     fi
 fi
 
@@ -102,12 +139,24 @@ After compaction, run /claude-harness:start only if context feels incomplete.
 TIP: Opus 4.6 compaction is smarter than manual /clear - it preserves task-relevant
 context automatically. Only run /checkpoint + /clear if you want a full reset."
 
-# Escape for JSON
-USER_MSG_ESCAPED=$(echo "$USER_MSG" | sed 's/"/\\"/g')
-CLAUDE_CONTEXT_ESCAPED=$(echo "$CLAUDE_CONTEXT" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
-
-# Output JSON response
-cat << EOF
+# Build output JSON using jq for safety
+if command -v jq >/dev/null 2>&1; then
+    jq -n \
+        --arg msg "$USER_MSG" \
+        --arg ctx "$CLAUDE_CONTEXT" \
+        '{
+            continue: true,
+            systemMessage: $msg,
+            hookSpecificOutput: {
+                hookEventName: "PreCompact",
+                additionalContext: $ctx
+            }
+        }'
+else
+    # Escape for JSON manually
+    USER_MSG_ESCAPED=$(printf '%s' "$USER_MSG" | sed 's/"/\\"/g')
+    CLAUDE_CONTEXT_ESCAPED=$(printf '%s' "$CLAUDE_CONTEXT" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
+    cat << EOF
 {
   "continue": true,
   "systemMessage": "$USER_MSG_ESCAPED",
@@ -117,3 +166,4 @@ cat << EOF
   }
 }
 EOF
+fi

--- a/hooks/pre-tool-use
+++ b/hooks/pre-tool-use
@@ -5,6 +5,9 @@
 # Exit 0 with permissionDecision: "deny" = block the tool call
 # Exit 0 with no decision = allow
 
+# Safety net: ensure hook NEVER exits non-zero (which causes "hook error" in Claude Code)
+trap 'exit 0' ERR
+
 HARNESS_DIR="$CLAUDE_PROJECT_DIR/.claude-harness"
 
 # Skip if not a harness project
@@ -15,20 +18,29 @@ fi
 # Read stdin JSON
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
+# Parse JSON with jq (reliable) or grep fallback
+if command -v jq >/dev/null 2>&1; then
+    TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || TOOL_NAME=""
+else
+    TOOL_NAME=$(printf '%s' "$INPUT" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/') || TOOL_NAME=""
+fi
 
 # ============================================================================
 # BASH TOOL — Block dangerous git commands and state destruction
 # ============================================================================
 
 if [ "$TOOL_NAME" = "Bash" ]; then
-    COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
+    if command -v jq >/dev/null 2>&1; then
+        COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || COMMAND=""
+    else
+        COMMAND=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/') || COMMAND=""
+    fi
 
     DENY_REASON=""
 
     # Block checkout to main/master ONLY if an active loop is in progress
     # (autonomous flow legitimately checks out main between features)
-    if echo "$COMMAND" | grep -qE 'git\s+checkout\s+(main|master)\b'; then
+    if printf '%s' "$COMMAND" | grep -qE 'git\s+checkout\s+(main|master)\b'; then
         SESSIONS_DIR="$HARNESS_DIR/sessions"
         if [ -d "$SESSIONS_DIR" ]; then
             for sd in "$SESSIONS_DIR"/*/; do
@@ -36,8 +48,12 @@ if [ "$TOOL_NAME" = "Bash" ]; then
                 [ "$(basename "$sd")" = ".recovery" ] && continue
                 lf="$sd/loop-state.json"
                 [ -f "$lf" ] || continue
-                ls=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$lf" 2>/dev/null | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
-                if [ "$ls" = "in_progress" ]; then
+                if command -v jq >/dev/null 2>&1; then
+                    ls_val=$(jq -r '.status // empty' "$lf" 2>/dev/null) || ls_val=""
+                else
+                    ls_val=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$lf" 2>/dev/null | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/') || ls_val=""
+                fi
+                if [ "$ls_val" = "in_progress" ]; then
                     DENY_REASON="BLOCKED: git checkout main/master while a feature loop is in progress. Stay on your feature branch."
                     break
                 fi
@@ -46,45 +62,58 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     fi
 
     # Block force push
-    if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force'; then
+    if printf '%s' "$COMMAND" | grep -qE 'git\s+push\s+.*--force'; then
         DENY_REASON="BLOCKED: git push --force is destructive. Use normal push or ask the user."
     fi
 
     # Block reset --hard
-    if echo "$COMMAND" | grep -qE 'git\s+reset\s+--hard'; then
+    if printf '%s' "$COMMAND" | grep -qE 'git\s+reset\s+--hard'; then
         DENY_REASON="BLOCKED: git reset --hard discards changes. Use git stash or ask the user."
     fi
 
     # Block clean -f
-    if echo "$COMMAND" | grep -qE 'git\s+clean\s+-[a-zA-Z]*f'; then
+    if printf '%s' "$COMMAND" | grep -qE 'git\s+clean\s+-[a-zA-Z]*f'; then
         DENY_REASON="BLOCKED: git clean -f deletes untracked files permanently. Ask the user."
     fi
 
     # Block direct push to main
-    if echo "$COMMAND" | grep -qE 'git\s+push\s+origin\s+(main|master)\b'; then
+    if printf '%s' "$COMMAND" | grep -qE 'git\s+push\s+origin\s+(main|master)\b'; then
         DENY_REASON="BLOCKED: Direct push to main/master. Use a PR workflow instead."
     fi
 
     # Block rm -rf of harness state
-    if echo "$COMMAND" | grep -qE 'rm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+.*\.claude-harness'; then
+    if printf '%s' "$COMMAND" | grep -qE 'rm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+.*\.claude-harness'; then
         DENY_REASON="BLOCKED: Deleting .claude-harness would destroy all session state and memory."
     fi
 
     # Block branch -D (force delete)
-    if echo "$COMMAND" | grep -qE 'git\s+branch\s+-D\b'; then
+    if printf '%s' "$COMMAND" | grep -qE 'git\s+branch\s+-D\b'; then
         DENY_REASON="BLOCKED: git branch -D force-deletes a branch. Use -d for safe delete or ask the user."
     fi
 
     if [ -n "$DENY_REASON" ]; then
-        cat << EOF
+        # Use jq for safe JSON output if available
+        if command -v jq >/dev/null 2>&1; then
+            jq -n --arg reason "$DENY_REASON" '{
+                hookSpecificOutput: {
+                    hookEventName: "PreToolUse",
+                    permissionDecision: "deny",
+                    permissionDecisionReason: $reason
+                }
+            }'
+        else
+            # Escape quotes in deny reason for JSON safety
+            SAFE_REASON=$(printf '%s' "$DENY_REASON" | sed 's/"/\\"/g')
+            cat << EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": "$DENY_REASON"
+    "permissionDecisionReason": "$SAFE_REASON"
   }
 }
 EOF
+        fi
         exit 0
     fi
 fi
@@ -94,7 +123,11 @@ fi
 # ============================================================================
 
 if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
-    FILE_PATH=$(echo "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
+    if command -v jq >/dev/null 2>&1; then
+        FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || FILE_PATH=""
+    else
+        FILE_PATH=$(printf '%s' "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/') || FILE_PATH=""
+    fi
 
     DENY_REASON=""
 
@@ -102,20 +135,31 @@ if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
     # Note: loop-state.json and active.json are NOT blocked here because /flow
     # legitimately writes these files using Write/Edit tools. The hook cannot
     # distinguish between /flow state management and accidental writes.
-    if echo "$FILE_PATH" | grep -qE 'hooks/(hooks\.json|run-hook\.cmd|session-start|pre-compact|stop|pre-tool-use|permission-request|subagent-start|teammate-idle|task-completed)$'; then
+    if printf '%s' "$FILE_PATH" | grep -qE 'hooks/(hooks\.json|run-hook\.cmd|session-start|pre-compact|stop|pre-tool-use|permission-request|subagent-start|teammate-idle|task-completed)$'; then
         DENY_REASON="BLOCKED: Hook files are managed by the harness plugin. Do not self-modify."
     fi
 
     if [ -n "$DENY_REASON" ]; then
-        cat << EOF
+        if command -v jq >/dev/null 2>&1; then
+            jq -n --arg reason "$DENY_REASON" '{
+                hookSpecificOutput: {
+                    hookEventName: "PreToolUse",
+                    permissionDecision: "deny",
+                    permissionDecisionReason: $reason
+                }
+            }'
+        else
+            SAFE_REASON=$(printf '%s' "$DENY_REASON" | sed 's/"/\\"/g')
+            cat << EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": "$DENY_REASON"
+    "permissionDecisionReason": "$SAFE_REASON"
   }
 }
 EOF
+        fi
         exit 0
     fi
 fi


### PR DESCRIPTION
## Summary
- Replace fragile `grep -o "[^"]*"` JSON parsing with `jq` in `pre-tool-use`, `permission-request`, and `pre-compact` hooks (with grep fallback when jq unavailable)
- Add `trap 'exit 0' ERR` safety net to all three hooks — they never exit non-zero now
- Fix `pre-compact` invalid JSON generation when state variables are empty (defaults to `null`)
- Replace `echo "$VAR"` with `printf '%s' "$VAR"` to avoid escape sequence interpretation

## Test plan
- [x] `bash -n` syntax validation on all 3 modified hooks
- [x] 13/13 acceptance tests pass (escaped quotes, embedded JSON, malformed input, deny logic, pre-compact JSON validity)
- [ ] Manual verification: run Claude Code session and confirm no "PreToolUse:Bash hook error" messages

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)