### PR TITLE
fix: Ensure harness state files are committed during checkpoint and flow

### DIFF
--- a/skills/checkpoint/SKILL.md
+++ b/skills/checkpoint/SKILL.md
@@ -191,7 +191,8 @@ Arguments: $ARGUMENTS
 ## Phase 3: Commit & Push
 
 3. ALWAYS commit changes:
-   - Stage all modified files (except secrets/env files)
+   - **Stage harness state files first**: `git add .claude-harness/` (sessions/ and working/ are gitignored, so only persistent state is staged)
+   - Stage all other modified files: `git add -A` (except secrets/env files)
    - Check loop state to determine commit prefix:
      - Read session-scoped loop state: `.claude-harness/sessions/{session-id}/loop-state.json`
      - If session file doesn't exist, check legacy: `.claude-harness/loops/state.json`

--- a/skills/flow/references/autonomous-wrapper.md
+++ b/skills/flow/references/autonomous-wrapper.md
@@ -119,7 +119,7 @@ build: {build} | tests: {tests} | lint: {lint} | typecheck: {typecheck} | accept
 4. {if --team: "Create an Agent Team (tester, implementer, reviewer). Execute Mandatory Team Shutdown Gate before checkpoint."}
 5. {if NOT --team: "Implement directly -- but still follow ATDD order: acceptance tests first, then implementation."}
 6. Run ALL verification commands after implementation
-7. On pass: commit as `feat({feature-id}): {description}`, push, create/update PR with `Closes #{issueNumber}`
+7. On pass: stage ALL modified files including `.claude-harness/` state files (`git add .claude-harness/ && git add -A`), then commit as `feat({feature-id}): {description}`, push, create/update PR with `Closes #{issueNumber}`
 8. On fail: retry with escalation (attempts 1-5: high effort, 6-10: max, 11-15: max + full memory). Max 15 attempts.
 9. {if NOT --no-merge: "Merge PR (squash), close issue, delete branch, update feature status to 'passing', then archive"}
 10. {if --no-merge: "Stop at checkpoint. Do not merge."}
@@ -223,7 +223,13 @@ summary: {one-line summary of what was done}
 
 7. **Reset session state**: Clear loop-state.json, clear task references, clear working-context.json.
 
-8. **Brief per-feature report**: feature ID, status, attempts, commit hash, PR number, duration, memory updates count, progress (N/M features complete).
+8. **Commit harness state updates to main** (CRITICAL — orchestrator changes must be persisted):
+   - `git add .claude-harness/ && git status --porcelain .claude-harness/`
+   - If there are staged changes: `git commit -m "chore: update harness state after {feature-id}" && git push origin main`
+   - This captures: archived features, memory persistence, session briefing, progress updates
+   - Must happen BEFORE the next feature iteration to keep state consistent
+
+9. **Brief per-feature report**: feature ID, status, attempts, commit hash, PR number, duration, memory updates count, progress (N/M features complete).
 
 ---
 

--- a/skills/flow/references/checkpoint.md
+++ b/skills/flow/references/checkpoint.md
@@ -96,7 +96,9 @@ Next steps: {from working-context nextSteps}
 
 ## Phase 5.6: Commit, Push, PR
 
-1. Commit `feat(feature-XXX): {description}`, push to remote
-2. Create/update PR via `mcp__github__create_pull_request`: title, body with `Closes #{issue}`
-3. Mark Checkpoint task completed
-4. Display checkpoint summary: commit hash, PR number, task status
+1. **Stage harness state files**: `git add .claude-harness/` (sessions/ and working/ are gitignored, so only persistent state is staged — memory layers, features, progress, session-briefing, agents, config)
+2. Stage all other modified files: `git add -A`
+3. Commit `feat(feature-XXX): {description}`, push to remote
+4. Create/update PR via `mcp__github__create_pull_request`: title, body with `Closes #{issue}`
+5. Mark Checkpoint task completed
+6. Display checkpoint summary: commit hash, PR number, task status

--- a/skills/flow/references/implementation.md
+++ b/skills/flow/references/implementation.md
@@ -58,7 +58,7 @@ build: {build} | tests: {tests} | lint: {lint} | typecheck: {typecheck} | accept
 4. {if --team: "Create an Agent Team (tester, implementer, reviewer). Execute Mandatory Team Shutdown Gate before checkpoint."}
 5. {if NOT --team: "Implement directly -- but still follow ATDD order: acceptance tests first, then implementation."}
 6. Run ALL verification commands after implementation
-7. On pass: commit as `feat({feature-id}): {description}`, push, create/update PR with `Closes #{issueNumber}`
+7. On pass: stage ALL modified files including `.claude-harness/` state files (`git add .claude-harness/ && git add -A`), then commit as `feat({feature-id}): {description}`, push, create/update PR with `Closes #{issueNumber}`
 8. On fail: retry with escalation (attempts 1-5: high effort, 6-10: max, 11-15: max + full memory). Max 15 attempts.
 9. {if NOT --no-merge: "Merge PR (squash), close issue, delete branch, update feature status to 'passing', then archive: read archive.json (create if missing), append feature with archivedAt timestamp, remove from active.json, write both files"}
 10. {if --no-merge: "Stop at checkpoint. Do not merge."}
@@ -117,15 +117,21 @@ summary: {one-line summary of what was done}
   - `git fetch --prune`
 - **Clear session state**: clear loop-state.json, working-context.json
 - **Regenerate session briefing**: write `.claude-harness/session-briefing.md` if subagent didn't
+- **Commit harness state updates to main** (CRITICAL — orchestrator changes must be persisted):
+  - `git add .claude-harness/ && git status --porcelain .claude-harness/`
+  - If there are staged changes: `git commit -m "chore: update harness state (memory, features, briefing)" && git push origin main`
+  - This captures: archived features, memory persistence, session briefing, progress updates
 
 **If `failed` or `escalated`**:
 - Persist memory updates (failures)
+- **Commit harness state updates**: `git add .claude-harness/ && git commit -m "chore: persist harness state after {feature-id} failure" && git push` (on current branch)
 - Display failure summary with attempt count, last approach, last error
 - Suggest: retry with `/claude-harness:flow {feature-id}`, increase maxAttempts, or get help
 - Do NOT archive, do NOT switch to main
 
 **If `needs_review`**:
 - Display PR URL and status
+- **Commit harness state updates** (if any): `git add .claude-harness/ && git commit -m "chore: persist harness state" && git push` (on current branch)
 - Suggest: review PR then run `/claude-harness:merge`
 - Do NOT archive
 


### PR DESCRIPTION
## Summary

- Checkpoint and flow commands were not committing `.claude-harness/` state files (memory, features, progress, session-briefing) to the repo
- Orchestrator post-processing after subagent completion modified harness files but never committed them

## Root Causes

1. **Checkpoint commit step** didn't explicitly stage `.claude-harness/` files — Claude would only commit code changes, leaving harness state dirty
2. **Orchestrator post-processing** (after subagent returns in both standard and autonomous modes) modifies harness files (archiving, memory persistence, session briefing) but these changes were never committed since they happen after the subagent's commit

## Changes (4 files)

| File | Fix |
|------|-----|
| `skills/checkpoint/SKILL.md` | Explicit `git add .claude-harness/` before `git add -A` in Phase 3 |
| `skills/flow/references/checkpoint.md` | Same explicit staging in Phase 5.6 |
| `skills/flow/references/implementation.md` | Subagent instructions include harness staging; orchestrator commits harness state to main after merge/failure/review |
| `skills/flow/references/autonomous-wrapper.md` | Subagent instructions include harness staging; orchestrator commits harness state before next iteration |

## Test plan

- [ ] Run `/claude-harness:checkpoint` and verify `.claude-harness/` files are included in the commit
- [ ] Run `/claude-harness:flow` and verify harness state is committed both by subagent and orchestrator post-processing
- [ ] Run `/claude-harness:flow --autonomous` and verify harness state is committed between feature iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)