### PR TITLE
fix: double-quote ${CLAUDE_PLUGIN_ROOT} in hook commands so /bin/sh can expand it

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,10 @@ Then restart Claude Code and run `/claude-harness:setup`.
 
 ## Changelog
 
+### 2026-07-09 - Fix hook commands failing with unexpanded ${CLAUDE_PLUGIN_ROOT}
+
+- **Fix: `PreToolUse:Bash hook error ... ${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd: not found` on every tool call**: hooks.json wrapped the hook path in single quotes, which blocks shell variable expansion. Current Claude Code provides `CLAUDE_PLUGIN_ROOT` as an environment variable expanded by `/bin/sh` (rather than textually substituting it), so the literal unexpanded string reached the shell and every hook failed. All 8 hook commands now use double quotes, which work under both expansion regimes.
+
 ### 2026-07-02 - Modernize for current Claude Code APIs (speed + correctness)
 
 - **Fix: session liveness detection was always false**: The SessionStart hook recorded its own (immediately-dead) PID, so every other session was treated as stale — concurrent sessions deleted each other's live state and produced false interrupt markers. Sessions are now keyed by Claude Code's **native `session_id`** (read from hook stdin), and staleness is judged by transcript-file mtime (24h). Parallel sessions actually work now.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' session-start",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
             "timeout": 30
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' session-end",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-end",
             "timeout": 15
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' pre-compact",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-compact",
             "timeout": 30
           }
         ]
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' pre-tool-use",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-tool-use",
             "timeout": 5
           }
         ]
@@ -51,7 +51,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' permission-request",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" permission-request",
             "timeout": 5
           }
         ]
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' subagent-start",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" subagent-start",
             "timeout": 5
           }
         ]
@@ -74,7 +74,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' teammate-idle",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" teammate-idle",
             "timeout": 60
           }
         ]
@@ -85,7 +85,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' task-completed",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" task-completed",
             "timeout": 300
           }
         ]


### PR DESCRIPTION
## Summary
Every hook invocation failed with `PreToolUse:Bash hook error ... /bin/sh: 1: ${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd: not found` on current Claude Code.

hooks.json wrapped the hook path in **single quotes**, which block shell variable expansion. Current Claude Code provides `CLAUDE_PLUGIN_ROOT` as an environment variable expanded by `/bin/sh` rather than textually substituting it into the command string — so the literal unexpanded variable reached the shell. Double quotes work under both regimes (textual substitution and env-var expansion).

## Test plan
- Reproduced the exact failure with the single-quoted form under `sh -c` + env var (exit 127, identical message)
- All 8 registered hook commands executed via `sh -c "<command verbatim from hooks.json>"` with `CLAUDE_PLUGIN_ROOT` set: all resolve and run (teammate-idle's exit 2 is its designed gate signal)
- `jq` validation of hooks.json; repo-wide grep confirms no single-quoted `${CLAUDE_PLUGIN_ROOT}` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)